### PR TITLE
Blog app - API documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,9 @@ gem 'devise'
 gem 'cancancan'
 
 # display Swagger UI
-gem "rswag-ui"
+gem 'rswag-ui'
 # make API requests from Swagger UI
-gem "rswag-api"
+gem 'rswag-api'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ gem 'devise'
 
 gem 'cancancan'
 
+# display Swagger UI
+gem "rswag-ui"
+# make API requests from Swagger UI
+gem "rswag-api"
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,11 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rswag-api (2.11.0)
+      railties (>= 3.1, < 7.2)
+    rswag-ui (2.11.0)
+      actionpack (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
     rubocop (1.56.4)
       base64 (~> 0.1.1)
       json (~> 2.3)
@@ -292,6 +297,8 @@ DEPENDENCIES
   rails (~> 7.0.8)
   rails-controller-testing
   rspec-rails
+  rswag-api
+  rswag-ui
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   sprockets-rails

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   get '/sign_out_user', to: 'users#sign_out_user', as: 'sign_out_user'
   devise_for :users
   resources :users, only: %i[index show] do

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: Blog App API
+  version: v1
+paths:
+  /api/v1/users/{user_id}/posts:
+    get:
+      summary: List Posts for a User
+      tags:
+        - Posts
+      parameters:
+        - name: user_id
+          in: path
+          description: User ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Success - Posts listed
+        '401':
+          description: Unauthorized
+
+  /api/v1/posts/{post_id}/comments:
+    get:
+      summary: List Comments for a Post
+      tags:
+        - Comments
+      parameters:
+        - name: post_id
+          in: path
+          description: Post ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Success - Comments listed
+        '401':
+          description: Unauthorized
+
+    post:
+      summary: Add a Comment to a Post
+      tags:
+        - Comments
+      parameters:
+        - name: post_id
+          in: path
+          description: Post ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '201':
+          description: Success - Comment created
+        '422':
+          description: Unprocessable Entity
+        '401':
+          description: Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+              required:
+                - text
+servers:
+  - url: https://127.0.0.1:3000/


### PR DESCRIPTION
# [Exercise](https://github.com/microverseinc/curriculum-rails/blob/main/blog-app/blog_app_api_documentation.md#exercise)
- In this exercise, you will add documentation for your API endpoints using [rswag](https://github.com/rswag/rswag). 
- Remember that this involves writing the specs that will then be turned into actual documentation and accessible in [swagger-ui](https://github.com/swagger-api/swagger-ui) at /api-docs


## [Instructions](https://github.com/microverseinc/curriculum-rails/blob/main/blog-app/blog_app_api_documentation.md#instructions)
- Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for your existing endpoints.
- Generate the documentation.